### PR TITLE
Fix push to saved covers array, will now display covers on pagegit st…

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,13 @@ function showFormPage() {
   randomCoverButton.classList.add('hidden');
   savedView.classList.add('hidden');
 };
+function saveCover() {
+  if (savedCovers.includes(currentCover)) {
+    console.log(false);
+  } else {
+    return savedCovers.push(currentCover)
+  }
+};
 function showSavedCovers() {
   // will display the hardcoded example, not pulling in freshly saved array items
   savedView.classList.remove('hidden');
@@ -107,11 +114,4 @@ function createUserCover() {
   randomCoverButton.classList.remove('hidden');
   saveCoverButton.classList.remove('hidden');
   event.preventDefault();
-};
-function saveCover() {
-  if (savedCovers.includes(currentCover)) {
-    console.log(false);
-  } else {
-    return savedCovers.push(currentCover)
-  }
 };


### PR DESCRIPTION
**Is this a fix or a feature?**
fix

**What is the change?**
relocated saveCover function

**What does it fix?**
click on saveCover button will now push to savedCovers array and display saved covers on correct page

**Where should the reviewer start?**
lines 63-69

**How should this be tested?**
console.log savedCovers array and test functionality in browser
